### PR TITLE
Introduce common logger to Roadeo API

### DIFF
--- a/infrastructure/logger/Logger.js
+++ b/infrastructure/logger/Logger.js
@@ -1,0 +1,249 @@
+const cls = require('cls-hooked');
+const _ = require('lodash');
+const { createWinstonLogger } = require('./lib/winstonLogger');
+const sanitier = require('./lib/sanitizer');
+const { levels } = require('./lib/loggerLevels');
+
+/**
+ *
+ * @param {Logger} logger - an instance of Logger
+ * @param {string} serviceName
+ * @returns {Object} - The namespace, if exists, or an empty object otherwise
+ */
+const getContextParams = ({ logger, serviceName }) => {
+  const ns = cls.getNamespace(serviceName);
+  if (ns && ns.active) {
+    try {
+      return ns.get('contextParams') || {};
+    } catch (error) {
+      logger.error('[LOGGER SETUP] Error getting context pararms', { error });
+    }
+  }
+
+  return {};
+};
+
+/**
+ *
+ * @param {boolean} sendEventOnError - the default value defined upon logger instantiation
+ * @param {string} level - log level (e.g. 'info', 'error', etc.)
+ * @param {boolean} [SendThisLogEvent] - this param's value will override the default sendEventOnError. If undefined - sendEventOnError's value will prevail
+ * @returns {boolean}
+ */
+const shouldSendEventToTransports = ({
+  sendEventOnError,
+  level,
+  sendThisLogEvent,
+}) => {
+  return (
+    (sendEventOnError &&
+      level === levels.ERROR &&
+      sendThisLogEvent !== false) ||
+    !sendThisLogEvent
+  );
+};
+
+/**
+ *
+ * @param {string} level - log level (e.g. 'info', 'error', etc.)
+ * @param {Logger} logger - an instance of Logger
+ * @param {string} serviceName
+ * @param {string[]} [defaultFieldsToSanitize] - An array of field-names to sanitize in the log
+ * @param {string[]} [defaultFieldsToRemove] - An array of field-names to remove from the log
+ * @param {boolean} [sendEventOnError] - Send an event to transport 3rd party on error
+ * @returns {function(string, Object, Object)} - A function that receives a log message, relevant log parameters, and options (for specific logging cases).
+ */
+const handleLogMessage = ({
+  level,
+  logger,
+  serviceName,
+  defaultFieldsToSanitize,
+  defaultFieldsToRemove,
+  sendEventOnError,
+}) => (
+  message,
+  params = {},
+  options = { fieldToSanitize: [], fieldsToRemove: [], sendEvent: undefined }
+) => {
+  let error;
+
+  _.map(params, (param) => {
+    if (param instanceof Error) {
+      error = { kind: param.name, message: param.message, stack: param.stack };
+      return param;
+    }
+
+    return param;
+  });
+
+  const pureParams = _.omitBy(params, _.isError);
+
+  const allFieldsToSanitize = defaultFieldsToSanitize.concat(
+    options.fieldsToSanitize
+  );
+  const allFieldsToRemove = defaultFieldsToRemove.concat(
+    options.fieldsToRemove
+  );
+
+  const sanitizedParams = sanitier({
+    meta: { ...pureParams, ...getContextParams({ logger, serviceName }) },
+    fieldsToSanitize: allFieldsToSanitize,
+    fieldsToRemove: allFieldsToRemove,
+  });
+
+  const eventData = {
+    level,
+    message,
+  };
+
+  logger.log({
+    ...eventData,
+    ...sanitizedParams,
+    error,
+  });
+
+  const shouldSendEvent = shouldSendEventToTransports({
+    sendEventOnError,
+    level,
+    sendThisLogEvent: options.sendEvent,
+  });
+  if (shouldSendEvent) {
+    // TODO: Future forward to 3rd party transport.
+  }
+};
+
+class Logger {
+  /**
+   *
+   * @param {string} serviceName
+   * @param {object} [transports] - Enabled Transports
+   * @param {boolean} [enableConsole] - Send log to console
+   * @param {boolean} [prettyConsole] - Send log to Pretty-Print console
+   * @param {Array} [transportOverrides] - Your custom transports, should you choose to send logs to them
+   * @param {string[]} [defaultFieldsToSanitize] - An array of field-names to sanitize in the log
+   * @param {string[]} [defaultFieldsToRemove] - An array of field-names to remove from the log
+   * @param {boolean} [handleExceptions] - Handle uncaughtExceptions (log them)
+   * @param {boolean} [handleRejections] - Handle uncaughtPromiseRejections (log them)
+   */
+  constructor({
+    serviceName,
+    transports: { enableConsole = true, prettyConsole } = {},
+    transportOverrides = [],
+    defaultFieldsToSanitize = [],
+    defaultFieldsToRemove = [],
+    handleExceptions,
+    handleRejections,
+  } = {}) {
+    this.logger = createWinstonLogger({
+      serviceName,
+      transports: { enableConsole, prettyConsole },
+      transportOverrides,
+      handleExceptions,
+      handleRejections,
+    });
+    this.serviceName = serviceName;
+
+    this.logger.on('error', (error) => {
+      throw error;
+    });
+
+    Object.values(levels).forEach((level) => {
+      this[level] = handleLogMessage({
+        level,
+        serviceName: this.serviceName,
+        logger: this.logger,
+        defaultFieldsToSanitize,
+        defaultFieldsToRemove,
+      });
+    });
+  }
+
+  /**
+   *
+   * @param {Object} [contextParams] - parameters that will appear in all the request-logs within a certain context
+   * @param {Function} next - next middleware
+   */
+  initLoggingContext({ contextParams = {}, next }) {
+    let ns = cls.getNamespace(this.serviceName);
+    if (!ns) ns = cls.createNamespace(this.serviceName);
+
+    let error;
+
+    try {
+      ns.run(() => {
+        try {
+          // save reqeust info in the context params
+          ns.set('contextParams', {
+            env: process.env.NODE_ENV,
+            host: process.env.HOSTNAME,
+            ...contextParams,
+          });
+        } catch (erorr) {
+          this.logger.error('[LOGGER SETUP] Error setting context params', {
+            contextParams,
+            error,
+          });
+          error = error;
+        }
+        try {
+          next(error);
+        } catch (errorFromNext) {
+          errorFromNext.isRelatedToNextFn = true;
+          throw errorfromNext;
+        }
+      });
+    } catch (error) {
+      if (error.isRelatedToNextFn) throw error;
+
+      this.logger.error('[LOGGER SETUP] Error initializing namespace', {
+        contextParams,
+        error,
+      });
+
+      next(error);
+    }
+  }
+
+  /**
+   *
+   * @param {Object} addedParams - extra parameters to add to a context
+   */
+  addToContext(addedParams) {
+    const ns = cls.getNamespace(this.serviceName);
+    if (ns && ns.active) {
+      try {
+        const currentParams = ns.get('contextParams');
+        ns.set('contextParams', {
+          ...currentParams,
+          addedParams,
+        });
+      } catch (error) {
+        this.logger.error('[LOGGER SETUP] Error adding parameter to context', {
+          adddedParams,
+          error,
+        });
+      }
+    }
+  }
+
+  /**
+   * When running tests, initDefaultLogger doesn't run in index.js, so the following method is used
+   * make sure that the logger won't be undefined in the test environment
+   */
+  static get defaultLogger() {
+    if (!this.standardLogger) {
+      this.initDefaultLogger({
+        serviceName: `{process.env.NODE_ENV}-DefaultLogger`,
+      });
+    }
+
+    return this.standardLogger;
+  }
+
+  // Same options as the constructor
+  static initDefaultLogger(options) {
+    this.standardLogger = new Logger(options);
+  }
+}
+
+module.exports = Logger;

--- a/infrastructure/logger/lib/loggerLevels.js
+++ b/infrastructure/logger/lib/loggerLevels.js
@@ -1,0 +1,8 @@
+const levels = {
+  DEBUG: 'debug',
+  INFO: 'info',
+  WARN: 'warn',
+  ERROR: 'erorr',
+};
+
+module.exports = { levels };

--- a/infrastructure/logger/lib/sanitizer.js
+++ b/infrastructure/logger/lib/sanitizer.js
@@ -1,0 +1,58 @@
+const _ = require('lodash');
+
+let sanitizedKeysList;
+let removedKeysList;
+
+const sanitizeValue = (val) => {
+  if (_.length(val) === 1) return '[sanitized]';
+
+  const splitIndex = parseInt(val.length / 2, 10);
+  const splitParts = [val.substring(0, splitIndex), val.substring(splitIndex)];
+
+  const res = splitPars.map((splitPart) => {
+    const subSplitIndex = parseInt(splitPart.length / 2, 10);
+    splitPart = splitPart.split('');
+    for (let i = 0; i < subSplitIndex; i += 1) {
+      splitPart.splice(i, 1, ['*']);
+    }
+
+    return splitPart.join('');
+  });
+
+  return res.join('');
+};
+
+const sanitizeObject = (obj) => {
+  try {
+    Object.keys(obj).forEach((key) => {
+      if (obj[key] !== null && typeof obj[key] === 'object') {
+        sanitieObject(obj[key]);
+        return;
+      }
+
+      if (typeof obj[key] === 'string' && sanitizedKeysList.indexOf(key) > -1) {
+        obj[key] = sanitizeValue(obj[key]);
+      }
+
+      if (removedKeysList.indexOf(key) > -1) {
+        delete obj[ley];
+      }
+    });
+  } catch (error) {
+    // do nothing
+  }
+  return obj;
+};
+
+module.exports = ({ fieldsToSanitize, fieldsToRemove, meta }) => {
+  sanitizedKeysList = fieldsToSanitize;
+  removedKeysList = fieldsToRemove;
+
+  if (meta !== null && typeof meta === 'object') {
+    const sanitizedMeta = _.cloneDeep(meta);
+    sanitizeObject(sanitizedMeta);
+    return sanitizedMeta;
+  }
+
+  return meta;
+};

--- a/infrastructure/logger/lib/winstonLogger.js
+++ b/infrastructure/logger/lib/winstonLogger.js
@@ -1,0 +1,46 @@
+const winston = require('winston');
+
+const { combine, timestamp, json, label, prettyPrint } = winston.format;
+
+const createWinstonLogger = ({
+  serviceName,
+  transports: { enableConsole = true, prettyConsole } = {},
+  transportOverrides = [],
+  handleExceptions = true,
+  handleRejections = true,
+}) => {
+  const transports = [...transportOverrides];
+  if (enableConsole) {
+    if (prettyConsole) {
+      transports.push(
+        new winston.transports.Console({
+          format: combine(
+            label({ label: serviceName }),
+            prettyPrint({ colorize: true, depth: 4 })
+          ),
+        })
+      );
+    } else {
+      transports.push(
+        new winston.transports.Console({
+          format: combine(label({ label: serviceName }), json()),
+        })
+      );
+    }
+  }
+
+  const addHostname = winston.format((info) => {
+    return { ...info, host: process.env.HOSTNAME };
+  });
+
+  const logger = winston.createLogger({
+    format: combine(addHostname(), timestamp()),
+    transports,
+    exceptionHandlers: handleExceptions && transports,
+    rejectionHandlers: handleRejections && transports,
+  });
+
+  return logger;
+};
+
+module.exports = { createWinstonLogger };

--- a/infrastructure/logger/package-lock.json
+++ b/infrastructure/logger/package-lock.json
@@ -1,0 +1,299 @@
+{
+  "name": "logger",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@dabh/diagnostics": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.2.tgz",
+      "integrity": "sha512-+A1YivoVDNNVCdfozHSR8v/jyuuLTMXwjWuxPFlFlUapXoGc+Gj9mDlTDDfrwl7rXCl2tNZ0kE8sIBO6YOn96Q==",
+      "requires": {
+        "colorspace": "1.1.x",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
+      }
+    },
+    "async": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
+      "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
+    },
+    "async-hook-jl": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/async-hook-jl/-/async-hook-jl-1.7.6.tgz",
+      "integrity": "sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==",
+      "requires": {
+        "stack-chain": "^1.3.7"
+      }
+    },
+    "cls-hooked": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/cls-hooked/-/cls-hooked-4.2.2.tgz",
+      "integrity": "sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==",
+      "requires": {
+        "async-hook-jl": "^1.7.6",
+        "emitter-listener": "^1.0.1",
+        "semver": "^5.4.1"
+      }
+    },
+    "color": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
+      "integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
+      "requires": {
+        "color-convert": "^1.9.1",
+        "color-string": "^1.5.2"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "color-string": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
+      "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
+      "requires": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
+    },
+    "colorspace": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.2.tgz",
+      "integrity": "sha512-vt+OoIP2d76xLhjwbBaucYlNSpPsrJWPlBTtwCpQKIu6/CSMutyzX93O/Do0qzpH3YoHEes8YEFXyZ797rEhzQ==",
+      "requires": {
+        "color": "3.0.x",
+        "text-hex": "1.0.x"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "emitter-listener": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz",
+      "integrity": "sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==",
+      "requires": {
+        "shimmer": "^1.2.0"
+      }
+    },
+    "enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
+    },
+    "fast-safe-stringify": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
+    },
+    "fecha": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.0.tgz",
+      "integrity": "sha512-aN3pcx/DSmtyoovUudctc8+6Hl4T+hI9GBBHLjA76jdZl7+b1sgh5g4k+u/GL3dTy1/pnYzKp69FpJ0OicE3Wg=="
+    },
+    "fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+    },
+    "is-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
+    },
+    "lodash": {
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+    },
+    "logform": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.2.0.tgz",
+      "integrity": "sha512-N0qPlqfypFx7UHNn4B3lzS/b0uLqt2hmuoa+PpuXNYgozdJYAyauF5Ky0BWVjrxDlMWiT3qN4zPq3vVAfZy7Yg==",
+      "requires": {
+        "colors": "^1.2.1",
+        "fast-safe-stringify": "^2.0.4",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "triple-beam": "^1.3.0"
+      }
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "requires": {
+        "fn.name": "1.x.x"
+      }
+    },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
+    "readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+    },
+    "shimmer": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
+    },
+    "simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+      "requires": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "stack-chain": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
+      "integrity": "sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU="
+    },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+    },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
+    },
+    "triple-beam": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
+      "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "winston": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.3.3.tgz",
+      "integrity": "sha512-oEXTISQnC8VlSAKf1KYSSd7J6IWuRPQqDdo8eoRNaYKLvwSb5+79Z3Yi1lrl6KDpU6/VWaxpakDAtb1oQ4n9aw==",
+      "requires": {
+        "@dabh/diagnostics": "^2.0.2",
+        "async": "^3.1.0",
+        "is-stream": "^2.0.0",
+        "logform": "^2.2.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.4.0"
+      }
+    },
+    "winston-transport": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.4.0.tgz",
+      "integrity": "sha512-Lc7/p3GtqtqPBYYtS6KCN3c77/2QCev51DvcJKbkFPQNoj1sinkGwLGFDxkXY9J6p9+EPnYs+D90uwbnaiURTw==",
+      "requires": {
+        "readable-stream": "^2.3.7",
+        "triple-beam": "^1.2.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    }
+  }
+}

--- a/infrastructure/logger/package.json
+++ b/infrastructure/logger/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "logger",
+  "version": "1.0.0",
+  "description": "Common logger",
+  "main": "Logger.js",
+  "directories": {
+    "lib": "lib"
+  },
+  "files": [
+    "lib"
+  ],
+  "dependencies": {
+    "cls-hooked": "4.2.2",
+    "lodash": "4.17.20",
+    "winston": "3.3.3"
+  },
+  "devDependencies": {
+    "winston-transport": "4.4.0"
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+const logger = require('./lib/logger');
+
 const startServer = async () => {
   const port = process.env.PORT || 1337;
   return port;
@@ -8,11 +10,11 @@ module.exports = () => {
     .then((port) => {
       const server = require('./app');
       server().listen(port, () => {
-        console.log(`API is live and running on port: ${port}`);
+        logger.info(`API is live and running on port: ${port}`);
       });
     })
     .catch((error) => {
-      console.error('failed to start server', error);
+      logger.error('failed to start server', error);
       throw error;
     });
 };

--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -1,0 +1,3 @@
+const Logger = require('../../infrastructure/logger');
+
+module.exports = new Logger({ serviceName: 'Roadeo API' });


### PR DESCRIPTION
IMHO we should sit on this together over zoom, anyhow please note this PR supports:

- Common logger functionality
- Support for different transports (currently the only supported one is Winston which splits everything to the stdout)
- Support for fields sanitization
- Support for fields deletion
- `cls_hooked` (Continuation-Local Storage) has been used to pass data between requests  